### PR TITLE
Simplify unit test CI checks

### DIFF
--- a/.github/workflows/deploy-check.yml
+++ b/.github/workflows/deploy-check.yml
@@ -48,14 +48,14 @@ jobs:
     outputs:
       changed_services: ${{ steps.changed-services.outputs.changed_services }}
 
-  service-deploy-build:
+  deploy-service-build:
     if: needs.detect-changed-services.outputs.changed_services != ''
     runs-on: ubuntu-24.04
     strategy:
       matrix:
         service: ${{ fromJSON(needs.detect-changed-services.outputs.changed_services) }}
     concurrency:
-      group: ${{ github.ref }}-${{ matrix.service }}-service-deploy-build
+      group: ${{ github.ref }}-${{ matrix.service }}-deploy-service-build
       cancel-in-progress: true
     needs: detect-changed-services
     steps:
@@ -103,16 +103,11 @@ jobs:
             **/build
             ${{ matrix.service }}/infra
 
-  service-deploy-test:
-    if: needs.detect-changed-services.outputs.changed_services != ''
+  deploy-test:
     runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        service: ${{ fromJSON(needs.detect-changed-services.outputs.changed_services) }}
     concurrency:
-      group: ${{ github.ref }}-${{ matrix.service }}-service-deploy-test
+      group: ${{ github.ref }}-deploy-test
       cancel-in-progress: true
-    needs: detect-changed-services
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -129,27 +124,19 @@ jobs:
           bash tools/scripts/secrets.sh
       - name: Test
         run: |
-          set -Eeuo pipefail
-          
-          if [ -e "${{ matrix.service }}/gradlew" ]; then
-            # Need to explicitly cd into each service, otherwise we get yarn cache clashes
-            cd ${{ matrix.service }}
-            ./gradlew --no-daemon --continue jsTest
-            cd ..
-          else
-            echo "Skipping step as required file doesn't exist"
-          fi
+          set -Eeuo pipefail 
+          ./gradlew --no-daemon --continue jsTest
       - name: Generate test report
         uses: mikepenz/action-junit-report@v4
         if: always() # Ensure all test reports are collected, even after errors
         with:
           report_paths: |
             **/TEST-*.xml
-          check_name: service-check-test-results (${{ matrix.service }})
+          check_name: deploy-test-results
       - name: Artifacts
         uses: actions/upload-artifact@v4
         if: always() # Ensure all artifacts are collected, even after errors
         with:
-          name: Tests (${{ matrix.service }})
+          name: Tests
           path: |
             **/TEST-*.xml

--- a/.github/workflows/staging-check.yml
+++ b/.github/workflows/staging-check.yml
@@ -48,14 +48,14 @@ jobs:
     outputs:
       changed_services: ${{ steps.changed-services.outputs.changed_services }}
 
-  service-check-build:
+  check-service-build:
     if: needs.detect-changed-services.outputs.changed_services != ''
     runs-on: ubuntu-24.04
     strategy:
       matrix:
         service: ${{ fromJSON(needs.detect-changed-services.outputs.changed_services) }}
     concurrency:
-      group: ${{ github.ref }}-${{ matrix.service }}-service-check-build
+      group: ${{ github.ref }}-${{ matrix.service }}-check-service-build
       cancel-in-progress: true
     needs: detect-changed-services
     steps:
@@ -112,16 +112,11 @@ jobs:
             **/build
             ${{ matrix.service }}/infra
 
-  service-check-test:
-    if: needs.detect-changed-services.outputs.changed_services != ''
+  check-test:
     runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        service: ${{ fromJSON(needs.detect-changed-services.outputs.changed_services) }}
     concurrency:
-      group: ${{ github.ref }}-${{ matrix.service }}-service-check-test
+      group: ${{ github.ref }}-check-test
       cancel-in-progress: true
-    needs: detect-changed-services
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -138,27 +133,19 @@ jobs:
           bash tools/scripts/secrets.sh
       - name: Test
         run: |
-          set -Eeuo pipefail
-          
-          if [ -e "${{ matrix.service }}/gradlew" ]; then
-            # Need to explicitly cd into each service, otherwise we get yarn cache clashes
-            cd ${{ matrix.service }}
-            ./gradlew --no-daemon --continue jsTest
-            cd ..
-          else
-            echo "Skipping step as required file doesn't exist"
-          fi
+          set -Eeuo pipefail 
+          ./gradlew --no-daemon --continue jsTest
       - name: Generate test report
         uses: mikepenz/action-junit-report@v4
         if: always() # Ensure all test reports are collected, even after errors
         with:
           report_paths: |
             **/TEST-*.xml
-          check_name: service-check-test-results (${{ matrix.service }})
+          check_name: check-test-results
       - name: Artifacts
         uses: actions/upload-artifact@v4
         if: always() # Ensure all artifacts are collected, even after errors
         with:
-          name: Tests (${{ matrix.service }})
+          name: Tests
           path: |
             **/TEST-*.xml

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+--install.mutex network

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,10 @@
-// This file is intentionally empty as each sub-project should be independent. These tasks allow us to build and run it
-// as one from the repository root.
-// TODO: Consider if this still makes sense at scale
-val taskNames = listOf("clean", "assemble")
+/*
+This file is intentionally empty as each sub-project should be independent. These tasks below allow us to execute
+common actions for all projects right from the project root.
+- clean, assemble and kotlinUpgradeYarnLock are used for local development
+- jsTest is used to run all unit tests in one go (eg within the CI)
+*/
+val taskNames = listOf("clean", "assemble", "jsTest", "kotlinUpgradeYarnLock")
 taskNames.forEach { taskName ->
     tasks.register(taskName) {
         dependsOn(

--- a/gradle-plugins/build.gradle.kts
+++ b/gradle-plugins/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.21")
 }
 
-val taskNames = listOf("clean", "assemble")
+val taskNames = listOf("clean", "assemble", "jsTest", "kotlinUpgradeYarnLock")
 taskNames.forEach {  taskName ->
     tasks.register("${taskName}All") {
         tasks.findByName(taskName)?.let { dependsOn(it) }

--- a/landing-page-web/build.gradle.kts
+++ b/landing-page-web/build.gradle.kts
@@ -4,7 +4,7 @@ allprojects {
     }
 }
 
-val taskNames = listOf("clean", "assemble")
+val taskNames = listOf("clean", "assemble", "jsTest", "kotlinUpgradeYarnLock")
 taskNames.forEach {  taskName ->
     tasks.register("${taskName}All") {
         tasks.findByName(taskName)?.let { dependsOn(it) }

--- a/proxy-web/build.gradle.kts
+++ b/proxy-web/build.gradle.kts
@@ -4,7 +4,7 @@ allprojects {
     }
 }
 
-val taskNames = listOf("clean", "assemble")
+val taskNames = listOf("clean", "assemble", "jsTest", "kotlinUpgradeYarnLock")
 taskNames.forEach {  taskName ->
     tasks.register("${taskName}All") {
         tasks.findByName(taskName)?.let { dependsOn(it) }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,19 @@
+plugins {
+    // Allows publishing build scans when common tasks run from the project root, eg jsTest
+    id("com.gradle.develocity") version("3.18.1")
+}
+
 rootProject.name = "personal-website-kotlinjs"
 
 // Add or remove projects here from the common build. Alternatively, each project can be opened in isolation.
 includeBuild("gradle-plugins")
 includeBuild("landing-page-web")
 includeBuild("proxy-web")
+
+develocity {
+    buildScan {
+        termsOfUseUrl.set("https://gradle.com/help/legal-terms-of-use")
+        termsOfUseAgree.set("yes")
+        publishing.onlyIf { true }
+    }
+}


### PR DESCRIPTION
<!-- Feel free to delete irrelevant sections or add new ones as you see fit. -->

## What does this pull request change?

This PR makes all unit tests run in one step and removes the old matrix. This was possible thanks to the `.yarnrc` file which allowed setting the `--mutex` flag that configured yarn to use a single instance when resolving dependencies. This was key in the multi-project setup as it was previously resolving dependencies in parallel, causing cache issues.

## How is this change tested?

Manually and with existing checks.

---

[Writing Kotlin Multiplatform tests](https://kotlinlang.org/docs/js-running-tests.html)
